### PR TITLE
patched add to stop from overriding vars

### DIFF
--- a/tests/xontrib_chatgpt/test_chatmanager.py
+++ b/tests/xontrib_chatgpt/test_chatmanager.py
@@ -92,6 +92,10 @@ def test_add_with_conflicting_name(xession, cm):
     cm.add("test")
     res = cm.add("test")
     assert res == "Chat with that name already exists!"
+    xession.ctx['glob'] = 'something'
+    res = cm.add('glob')
+    assert 'glob' in xession.ctx
+    assert res == "Variable with that name already exists!"
 
 
 def test_ls(xession, cm_events, cm, monkeypatch, capsys):

--- a/xontrib_chatgpt/chatmanager.py
+++ b/xontrib_chatgpt/chatmanager.py
@@ -129,6 +129,8 @@ class ChatManager:
         """
         if chat_name in self.chat_names():
             return "Chat with that name already exists!"
+        elif chat_name in XSH.ctx or chat_name in XSH.aliases:
+            return "Variable with that name already exists!"
         inst = ChatGPT(alias=chat_name, managed=True)
         XSH.ctx[chat_name] = inst
         self._instances[hash(inst)]["name"] = chat_name


### PR DESCRIPTION
Hi! Thank you for the awesome xontrib! I gave it a star!

Please take a look at my PR that ...
- Patched add on `chat-manager` to stop it from overriding already existing global variables/aliases

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
