### PR TITLE
Use subprocess macros call by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Use `chat-manager` to easily create and manage new chats
 
 ```xsh
 chat-manager add gpt
-gpt "Hello, what's your name?"
+gpt! Hello, what's your name?
 # ChatGPT responds here
 ```
 


### PR DESCRIPTION
To avoid quotes and escaping you can use [subprocess macros call](https://xon.sh/tutorial_macros.html#subprocess-macros):
```xsh
gpt! Hello "chatgpt"!
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
